### PR TITLE
changed map result link to display directions based on lat and long

### DIFF
--- a/js/wheel.js
+++ b/js/wheel.js
@@ -106,12 +106,14 @@ function stopRotateWheel() {
 	ctx.save();
 	
 	var resultName = restaurants[index].name.split(' ').join('+');
-	var mapURL = "http://maps.google.com/maps/search/";
-	
+	var mapURL = "http://maps.google.com/maps/dir/"; 
+	var originCoords = $('#latitude').val() + "," + $('#longitude').val();
+
+
 	//Display Result
 	$('.result h2').html(restaurants[index].name);
 	$('.result p.vicinity').html(restaurants[index].vicinity);
-	$('.result a.map').attr("href", mapURL + resultName + "/@" + restaurants[index].lat + "," + restaurants[index].lng);
+	$('.result a.map').attr("href", mapURL + originCoords + "/" + resultName + "/@" + restaurants[index].lat + "," + restaurants[index].lng);
 	
 	ctx.restore();
 	


### PR DESCRIPTION
Installing php on Windows is slightly more of a hassle than I'd like to deal with atm, but the change here should be simple enough. I just pull the user's selected lat and long from the input fields and add them to custom google map URL for directions.

If it doesn't work, I'll complete the php installation and get the /wheel/api/ json call to work on my end. 
